### PR TITLE
upgrade to latest version of the packages

### DIFF
--- a/scripts/qcow.sh
+++ b/scripts/qcow.sh
@@ -66,6 +66,8 @@ install_packages() (
     chroot_exec apt purge -y ubuntu-advantage-tools ubuntu-cloud-minimal ubuntu-drivers-common ubuntu-release-upgrader-core unattended-upgrades xz-utils
 
     chroot_exec apt autoremove -y
+    chroot_exec apt-mark hold linux-image-virtual
+    chroot_exec apt upgrade -y
     chroot_exec apt clean -y
     chroot_exec sh -c "rm -rf /var/lib/apt/lists/* /var/cache/apt/*"
 


### PR DESCRIPTION
The advantages are:
 - less security issues with the image
 - the local diffdisk size will be now smaller (as basedisk will have the package updates)